### PR TITLE
Handle (Float, Float) pixel values

### DIFF
--- a/src/Mapbox/Element.elm
+++ b/src/Mapbox/Element.elm
@@ -232,7 +232,7 @@ type alias TouchEvent =
 
 
 decodePoint =
-    Decode.map2 (\a b -> ( a, b )) (Decode.field "x" Decode.int) (Decode.field "y" Decode.int)
+    Decode.map2 (\a b -> ( round a, round b )) (Decode.field "x" Decode.float) (Decode.field "y" Decode.float)
 
 
 decodeEventData =


### PR DESCRIPTION
Versions of Google Chrome (and possibly other browsers) seem to return decimal pixel values for some zoom values. This results in silent errors; for Example01 specifically this causes Hover and Click events (onMouseMove and onClick respectively) to never make it to the update function.

I'm not sure if this is intended behavior for Chrome, but it's worth noting that in [mapbox/point-geometry](https://github.com/mapbox/point-geometry) (where Point and its fields are defined on the Mapbox side), x and y are both listed as being of type Number and representing "[lat/lon] or screen pixels, or any other sort of unit."