### PR TITLE
Removed encoding from rasterDEMMapbox

### DIFF
--- a/src/Mapbox/Source.elm
+++ b/src/Mapbox/Source.elm
@@ -307,7 +307,6 @@ rasterDEMMapbox id =
         (Json.Encode.object
             [ ( "type", Json.Encode.string "raster-dem" )
             , ( "url", Json.Encode.string "mapbox://mapbox.terrain-rgb" )
-            , ( "encoding", Json.Encode.string "mapbox" )
             ]
         )
 


### PR DESCRIPTION
Removing the mapbox encoding setting from rasterDEMMapbox appears to make it work