### PR TITLE
add a note about custom elements polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ install the accompanying npm library:
 
     npm install --save elm-mapbox
 
+Microsoft Edge you will needs a polyfill to use custom elements. The polyfill provides by
+webcomponents.org is known to work https://github.com/webcomponents/custom-elements
+
 Then include the library into your page. If you don't have any JS build system setup,
 probably the easiest is to add:
 


### PR DESCRIPTION
Thanks for the great library.

I have just been trying to deploy an app and discovered that custom elements are not supported on Edge/IE - I had not actually come across custom elements previously so it took me a while to connect the statement "This library uses a combination of ports and custom elements" with needing a polyfill - so I have added a note about polyfilling and pointed to the one I used.