### PR TITLE
Use Bool instead of Expression for visibility

### DIFF
--- a/generate-elm.js
+++ b/generate-elm.js
@@ -258,9 +258,9 @@ filter =
     Expression.encode >> Top "filter"
 
 {-| Whether this layer is displayed. -}
-visible : Expression CameraExpression Bool -> LayerAttr any
-visible vis =
-    Layout "visibility" <| Expression.encode <| Expression.ifElse vis (Expression.str "visible") (Expression.str "none")
+visible : Bool -> LayerAttr any
+visible isVisible =
+    Layout "visibility" <| Expression.encode <| Expression.str <| if isVisible then "visible" else "none"
 
 ${Object.entries(codes)
     .map(([section, codes]) => `-- ${section}\n\n${codes.join("\n")}`)

--- a/src/Mapbox/Layer.elm
+++ b/src/Mapbox/Layer.elm
@@ -319,9 +319,9 @@ filter =
 
 {-| Whether this layer is displayed.
 -}
-visible : Expression CameraExpression Bool -> LayerAttr any
-visible vis =
-    Layout "visibility" <| Expression.encode <| Expression.ifElse vis (Expression.str "visible") (Expression.str "none")
+visible : Bool -> LayerAttr any
+visible isVisible =
+    Layout "visibility" <| Expression.encode <| Expression.str <| if isVisible then "visible" else "none"
 
 
 

--- a/style-generator/src/Decoder.elm
+++ b/style-generator/src/Decoder.elm
@@ -194,6 +194,9 @@ decodeAttrs =
                         "filter" ->
                             decodeAttr "filter" (D.oneOf [ Decoder.Legacy.filter, Decode.expression ]) attrValue
 
+                        "visibility" ->
+                            decodeAttr "visible" (D.map ((==) "visible" >> bool) D.string) attrValue
+
                         other ->
                             decodeAttr (toCamelCaseLower attrName) Decode.expression attrValue
                 )

--- a/style-generator/src/MyElm/Syntax.elm
+++ b/style-generator/src/MyElm/Syntax.elm
@@ -1,6 +1,6 @@
 module MyElm.Syntax exposing
     ( QualifiedName, local, valueName, typeName, constructorName
-    , Expression, string, float, int, list, pair, triple, call0, call1, call2, call3, call4, calln, pipe, record
+    , Expression, string, float, int, bool, list, pair, triple, call0, call1, call2, call3, call4, calln, pipe, record
     , Type, type0, type1, type2, typen, recordType, functionType, pairType, tripleType, typeVar
     , Declaration, variable, fun1, customType, typeAlias
     , build, Exposing, opaque, withConstructors, exposeFn
@@ -319,6 +319,13 @@ float f =
 int : Int -> Expression
 int i =
     Literal (String.fromInt i)
+
+
+{-| A bool literal.
+-}
+bool : Bool -> Expression
+bool b =
+    Literal (if b then "True" else "False")
 
 
 {-| A list literal


### PR DESCRIPTION
Fixes #40. Updates `visible` to match the [style spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-background-visibility) `visibility` property and accept a `Bool` instead of an expression which isn't supported by this property